### PR TITLE
Brick action with no trigger or action raise error on attribute change

### DIFF
--- a/dist/brick-action.js
+++ b/dist/brick-action.js
@@ -4,7 +4,7 @@
 
   function cleanupHandler(el) {
     var pair = el._ns.listener;
-    if (pair[0]) {
+    if (pair && pair[0]) {
       pair[0].removeEventListener(pair[1], pair[2]);
     }
   }

--- a/src/brick-action.js
+++ b/src/brick-action.js
@@ -4,7 +4,7 @@
 
   function cleanupHandler(el) {
     var pair = el._ns.listener;
-    if (pair[0]) {
+    if (pair && pair[0]) {
       pair[0].removeEventListener(pair[1], pair[2]);
     }
   }


### PR DESCRIPTION
If brick action has no action or target, setupHandler will stop at `if (!action || !target) {` and will never set `el._ns.listener`

``` javascript
function setupHandler(el) {
    var source = el.getAttribute('source');
    var trigger = el.getAttribute('trigger') || 'click';
    var action = el.getAttribute('action');
    var target = el.getAttribute('target');
    var sourceEl;
    if (!action || !target) {
      return;
    }
....
    var listener = makeHandler(action, targetEl);
    el._ns.listener = [sourceEl, trigger, listener];
    sourceEl.addEventListener(trigger, listener);
  }
```

so on attribute change, cleanupHandler will have el._ns.listener to be undefined

``` javascript
function cleanupHandler(el) {
    var pair = el._ns.listener;
    if (pair[0]) {
      pair[0].removeEventListener(pair[1], pair[2]);
    }
  }
```

so `pair[0]` is undefined.
