### PR TITLE
No need of lodash, see #15

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "karma-chai": "^0.1.0",
     "karma-firefox-launcher": "^0.1.3",
     "karma-mocha": "^0.1.3",
-    "lodash": "^2.4.1",
     "mocha": "^1.20.1"
   }
 }


### PR DESCRIPTION
I had a old version of cheerio used by gulp-bower-dist, and lodash was complaining. I thought it was used somewhere else sorry.
